### PR TITLE
added handling for directories with no permission

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -114,6 +114,7 @@ exports.walk = function (start, callback) {
     if (stat.isDirectory()) {
 
       fs.readdir(start, function (err, files) {
+        if(!files) return callback(new Error("path: " + start + " is not accessible."));
         var coll = files.reduce(function (acc, i) {
           var abspath = path.join(start, i);
 
@@ -184,12 +185,12 @@ exports.path = {};
 exports.path.abspath = function (to) {
   var from;
   switch (to.charAt(0)) {
-    case "~": from = process.env.HOME; to = to.substr(1); break
-    case path.sep: from = ""; break
+    case "~": from = process.env.HOME; to = to.substr(1); break;
+    case path.sep: from = ""; break;
     default : from = process.cwd(); break
   }
   return path.join(from, to);
-}
+};
 
 exports.path.relativePath = function (base, compare) {
   base = base.split(path.sep);

--- a/tests/file_spec.js
+++ b/tests/file_spec.js
@@ -111,3 +111,13 @@ describe("file.path#relativePath", function () {
     done();
   });
 });
+
+describe("should handle directory with no access permission", function(){
+    it('should write error when no permission', function(done){
+        file.walk('test_resource/nopermdir', function (err) {
+            assert.notEqual(err, null);
+            assert.equal(err.message, 'path: test_resource/nopermdir is not accessible.');
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Hi, I ran into this bug when walking the /etc directory with a non-root user. In this pull request I provide the fix and a test for it. For the test to work, you need the 'test_resource/nopermdir' directory in the base path. The nopermdir directory must be inaccessible (chmod -rwx). I committed it in my fork, but it seems like it won't be merged automatically. Also some JSLint housekeeping for good measure :)