### PR TITLE
Fixes for windows paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 node_modules
 npm-debug.log
+.idea

--- a/lib/file.js
+++ b/lib/file.js
@@ -73,9 +73,8 @@ exports.mkdirs = function (_path, mode, callback) {
 // @mode: the file mode to create the directory with:
 //    ex: file.mkdirs("/tmp/dir", 755, function () {})
 exports.mkdirsSync = function (_path, mode) {
-  if (_path[0] !== path.sep) {
-    _path = path.join(process.cwd(), _path)
-  }
+
+  _path = path.resolve(process.cwd(), _path);
 
   var dirs = _path.split(path.sep);
   var walker = [dirs.shift()];
@@ -182,16 +181,26 @@ exports.walkSync = function (start, callback) {
 exports.path = {};
 
 exports.path.abspath = function (to) {
+  to = path.normalize(to);
   var from;
-  switch (to.charAt(0)) {
-    case "~": from = process.env.HOME; to = to.substr(1); break
-    case path.sep: from = ""; break
-    default : from = process.cwd(); break
+
+  if (to.charAt(0) === '~') {
+    from = "";
+    to = process.env.HOME + to.substr(1);
   }
-  return path.join(from, to);
+  else if (to.indexOf(path.sep) === 0) {
+    from = "";
+  }
+  else {
+    from = process.cwd();
+  }
+  return path.resolve(from, to);
 }
 
 exports.path.relativePath = function (base, compare) {
+  base = path.normalize(base);
+  compare = path.normalize(compare);
+
   base = base.split(path.sep);
   compare = compare.split(path.sep);
 

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   { "url" : "http://github.com/aconbere/node-file-utils" }
 , "main" : "./lib/file"
 , "license": "MIT"
-, "devDependencies": { "mocha": "1.9.x" }
+, "devDependencies": { "mocha": "1.9.x" },
+  "scripts": {
+    "test": "mocha tests"
+  }
 }

--- a/tests/file_spec.js
+++ b/tests/file_spec.js
@@ -26,10 +26,21 @@ describe("file#mkdirs", function () {
   it("should make all the directories in the tree", function (done) {
     file.mkdirs("/test/test/test/test", 0755, function(err) {
       if (err) throw new Error(err);
-      assert.equal(madeDirs[0], "/test");
-      assert.equal(madeDirs[1], "/test/test");
-      assert.equal(madeDirs[2], "/test/test/test");
-      assert.equal(madeDirs[3], "/test/test/test/test");
+      assert.equal(madeDirs[0], path.resolve("/test"));
+      assert.equal(madeDirs[1], path.resolve("/test/test"));
+      assert.equal(madeDirs[2], path.resolve("/test/test/test"));
+      assert.equal(madeDirs[3], path.resolve("/test/test/test/test"));
+      done();
+    });
+  });
+
+  it("should make all the directories in the tree on windows", function (done) {
+    file.mkdirs(path.resolve("/test/test/test/test"), 0755, function(err) {
+      if (err) throw new Error(err);
+      assert.equal(madeDirs[0], path.resolve("/test"));
+      assert.equal(madeDirs[1], path.resolve("/test/test"));
+      assert.equal(madeDirs[2], path.resolve("/test/test/test"));
+      assert.equal(madeDirs[3], path.resolve("/test/test/test/test"));
       done();
     });
   });
@@ -45,10 +56,10 @@ describe("file#mkdirsSync", function () {
     file.mkdirsSync("/test/test/test/test", 0755, function(err) {
       if (err) throw new Error(err);
     });
-    assert.equal(madeDirs[0], "/test");
-    assert.equal(madeDirs[1], "/test/test");
-    assert.equal(madeDirs[2], "/test/test/test");
-    assert.equal(madeDirs[3], "/test/test/test/test");
+    assert.equal(madeDirs[0], path.resolve("/test"));
+    assert.equal(madeDirs[1], path.resolve("/test/test"));
+    assert.equal(madeDirs[2], path.resolve("/test/test/test"));
+    assert.equal(madeDirs[3], path.resolve("/test/test/test/test"));
     done();
   });
 });
@@ -82,13 +93,13 @@ describe("file.path#abspath", function () {
   });
 
   it("should convert ~ to the home directory", function (done) {
-    assert.equal(file.path.abspath("~"), file.path.join(process.env.HOME, ""));
-    assert.equal(file.path.abspath("~/test/dir"), file.path.join(process.env.HOME, "test/dir"));
+    assert.equal(file.path.abspath("~"), path.resolve(process.env.HOME));
+    assert.equal(file.path.abspath("~/test/dir"), path.resolve(process.env.HOME, "test/dir"));
     done();
   });
 
   it("should not convert paths begining with /", function (done) {
-    assert.equal(file.path.abspath("/x/y/z"), "/x/y/z");
+    assert.equal(file.path.abspath("/x/y/z"), path.resolve("/x/y/z"));
     done();
   });
 });


### PR DESCRIPTION
Using an absolute windows path (i.e. d:\test\test) it would fail silently. Checks on path.sep will not work if a unix-based path is given on a windows environment. Made changes accordingly and updated tests accordingly. 

It seems it should be possible and easier to make more use of the node path class, but not sure why that was not done so left that alone.

Tests pass on both windows and unix (mac). 